### PR TITLE
Markdown to reStructuredText migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,0 @@
-# zuul
-[![Travis](https://img.shields.io/travis/osamabinloggin/zuul.svg?style=flat-square)](https://travis-ci.org/osamabinloggin/zuul)
-[![Codecov](https://img.shields.io/codecov/c/github/osamabinloggin/zuul.svg?style=flat-square)](https://codecov.io/gh/osamabinloggin/zuul)
-
-Gatekeeper Slack app for user verification and access to secure channels.

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,17 @@
+=====================
+Zuul: the gate keeper
+=====================
+.. image:: https://img.shields.io/travis/osamabinloggin/zuul.svg?style=for-the-badge
+   :alt: Travis
+   :target: https://travis-ci.org/osamabinloggin/zuul
+.. image:: https://img.shields.io/codecov/c/github/osamabinloggin/zuul.svg?style=for-the-badge
+   :alt: Codecov
+   :target: https://codecov.io/gh/osamabinloggin/zuul
+
+About
+-----
+Zuul is a Slack workspace app which manages secure channels via a web of trust model.
+
+Design
+------
+*link TBD*


### PR DESCRIPTION
Remove Markdown documents in favor of reStructuredText exclusively